### PR TITLE
Add `RedemptionEngine`

### DIFF
--- a/staking-credentials/src/redemption/mod.rs
+++ b/staking-credentials/src/redemption/mod.rs
@@ -3,12 +3,8 @@
 //
 // This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
 // or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT> or http://opensource.org/licenses/MIT>, at your option.
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-#![crate_name = "staking_credentials"]
-
-pub mod common;
-pub mod issuance;
 pub mod redemption;

--- a/staking-credentials/src/redemption/redemption.rs
+++ b/staking-credentials/src/redemption/redemption.rs
@@ -1,0 +1,29 @@
+// This file is Copyright its original authors, visibile in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http:://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT> or http:://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::secp256k1::ecdsa::Signature;
+
+use crate::common::utils::Credentials;
+
+pub struct RedemptionEngine {
+
+}
+
+impl RedemptionEngine {
+	pub fn new() -> Self {
+		RedemptionEngine {
+
+		}
+	}
+
+	pub fn verify_credentials(_pubkey: PublicKey, _credential: Credentials, _signature: Signature) -> bool {
+		return true;
+	}
+}


### PR DESCRIPTION
All the crypto operations on the validity of credentials during the service deliverance should be done by `RedemptionEngine`.